### PR TITLE
Fix pypi repo name

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -45,14 +45,14 @@ jobs:
         name: python-package-distributions
         path: dist/
 
-  publish-to-testpypi:
-    name: Publish to TestPyPI
+  pypi-publish:
+    name: Publish to PyPI
     needs:
     - build
     runs-on: ubuntu-latest
 
     environment:
-      name: testpypi
+      name: pypi
       url: https://pypi.org/p/fmchisel
 
     permissions:
@@ -64,7 +64,7 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Publish distribution 📦 to TestPyPI
+    - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         verbose: true

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def get_optional_dependencies():
 verify_os()
 
 setup(
-    name="FMCHISEL",
+    name="fmchisel",
     package_dir={"": "src"},
     packages=find_packages(where="src", include=["fmchisel*"]),
     install_requires=get_default_dependencies(),


### PR DESCRIPTION
Fix pypi repo name.

<img width="932" height="174" alt="image" src="https://github.com/user-attachments/assets/5b85b7a0-5828-46d4-b739-7811d6b1d03b" />
