### PR TITLE
Put import of ModifierFactory to a try block

### DIFF
--- a/src/fmchisel/__init__.py
+++ b/src/fmchisel/__init__.py
@@ -1,13 +1,17 @@
 import logging
 
-from llmcompressor.modifiers.factory import ModifierFactory
-
 logger = logging.getLogger(__name__)
-try:
 
+try:
+    from llmcompressor.modifiers.factory import ModifierFactory
+
+except ImportError:
+    logger.info(
+        "Optional dependency 'llmcompressor' not found; skipping FMCHISEL modifier "
+        "registration. If you installed from source with the 'train' extra, this is expected."
+    )
+
+else:
     ModifierFactory._EXPERIMENTAL_PACKAGE_PATH = "fmchisel"
     ModifierFactory.refresh()
     logger.info("Registered FMCHISEL modifiers successfully.")
-
-except ImportError:
-    logger.info("llmcompressor not detected. FMCHISEL Modifiers will not be registered.")


### PR DESCRIPTION
Users who install with the train extra (which excludes llmcompressor) will hit an ImportError. This change wraps the llmcompressor import in try and logs that skipping FMCHISEL modifier registration is expected when using the train extra. When llmcompressor is available, registration proceeds as before.